### PR TITLE
v1.1.0

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cp }}-*
           CIBW_SKIP: "*-musllinux*"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           output-dir: wheelhouse
 


### PR DESCRIPTION
Fix
- Error 429: Too Many Requests (caused by `cibuildwheel`)