### PR TITLE
v1.1.0

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.0.1
 
-      - name: Pre-download virtualenv.pyz (Error 429 workaround)
+      - name: Pre-download virtualenv.pyz (Err. 429, macOS workaround)
         if: runner.os == 'macOS'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,6 +91,18 @@ jobs:
           curl -L -f -H "Authorization: Bearer $GITHUB_TOKEN" \
             "https://raw.githubusercontent.com/pypa/get-virtualenv/20.31.2/public/virtualenv.pyz" \
             -o ~/Library/Caches/cibuildwheel/virtualenv-20.31.2.pyz
+
+      - name: Pre-download virtualenv.pyz (Err. 429, Windows workaround)
+        if: runner.os == 'Windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $cacheDir = "$env:LOCALAPPDATA\pypa\cibuildwheel\Cache"
+          New-Item -ItemType Directory -Force -Path $cacheDir
+          $url = "https://raw.githubusercontent.com/pypa/get-virtualenv/20.31.2/public/virtualenv.pyz"
+          $dest = "$cacheDir\virtualenv-20.31.2.pyz"
+          Invoke-RestMethod -Uri $url -Headers @{Authorization="Bearer $env:GITHUB_TOKEN"} -OutFile $dest
 
       - name: Build wheels
         env:


### PR DESCRIPTION
ci: workaround for cibuildwheel 429 error on macOS/Windows runners