### PR TITLE
Fix satpos

### DIFF
--- a/docs/reference/parsing.md
+++ b/docs/reference/parsing.md
@@ -19,3 +19,4 @@ The `parsing` module is the entry point for data ingestion in `PyTECGg`. It leve
       members:
         - read_rinex_obs
         - read_rinex_nav
+        - read_rinex_nav_header

--- a/docs/reference/satellites.md
+++ b/docs/reference/satellites.md
@@ -13,10 +13,14 @@ The `satellites` module provides essential functions for GNSS orbit propagation 
 
 `prepare_ephemeris` now validates navigation records according to the orbit model actually used downstream:
 
-- **GPS, Galileo, BeiDou**: the function keeps one representative broadcast message per satellite and checks only the orbital fields strictly required for Keplerian position propagation.
+- **GPS, Galileo, BeiDou**: the function keeps every valid broadcast record per satellite, checking only the orbital fields strictly required for Keplerian position propagation. Position computation later selects the record whose `toe` is nearest to the observation epoch, since broadcast Keplerian parameters are only valid for ~±2 h around `toe` — reusing a single record across a multi-hour file would otherwise introduce 50–200 m biases. Records corrupted by the rinex-crate week-rollover `toe` parsing bug are filtered out and a warning is emitted.
 - **GLONASS**: the full message history is retained because state-vector propagation needs the closest valid epoch and the FDMA channel.
 
 This means a navigation message is not discarded, as long as the orbital solution is still sufficient to compute satellite geometry.
+
+### Time Systems and Leap Seconds
+
+Each broadcast record carries a `leap_seconds` field (UTC → GPST offset). The value is taken from the RINEX nav header via [`read_rinex_nav_header`][pytecgg.parsing.read_rinex_nav_header] (assigned to `GNSSContext.leap_seconds`) or falls back to `DEFAULT_LEAP_SECONDS_UTC_GPST` from `pytecgg.satellites.constants`. During position computation, observation epochs are shifted into the constellation's own time system before the elapsed-time-from-`toe` is computed: GPST for GPS / Galileo / QZSS, BDT for BeiDou (BDT = GPST − 14 s), and UTC for GLONASS.
 
 ---
 

--- a/pytecgg/context.py
+++ b/pytecgg/context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 import warnings
 
 SUPPORTED_SYSTEMS = {
@@ -75,6 +75,10 @@ class GNSSContext:
     systems: list[str] = field(default_factory=list)
     glonass_channels: dict[str, int] = field(default_factory=dict)
     freq_meta: dict[str, Any] = field(default_factory=dict)
+    # UTC -> GPST offset in seconds. Populate from the RINEX nav header via
+    # parsing.read_rinex_nav_header(). Falls back to DEFAULT_LEAP_SECONDS_UTC_GPST
+    # in constants.py if left unset.
+    leap_seconds: Optional[int] = None
 
     def __post_init__(self):
         if (

--- a/pytecgg/parsing/__init__.py
+++ b/pytecgg/parsing/__init__.py
@@ -1,3 +1,4 @@
+import gzip
 from pathlib import Path
 from typing import Union
 
@@ -8,7 +9,7 @@ from ..pytecgg import (
     read_rinex_nav as _read_rinex_nav,
 )
 
-__all__ = ["read_rinex_obs", "read_rinex_nav"]
+__all__ = ["read_rinex_obs", "read_rinex_nav", "read_rinex_nav_header"]
 
 
 def read_rinex_obs(
@@ -36,6 +37,55 @@ def read_rinex_obs(
         rec_pos,
         rinex_version,
     )
+
+
+def _open_rinex_text(path: Union[str, Path]):
+    """Open a RINEX file as text, transparently handling .gz."""
+    p = Path(path)
+    if p.suffix.lower() == ".gz":
+        return gzip.open(p, "rt", encoding="ascii", errors="replace")
+    return open(p, "r", encoding="ascii", errors="replace")
+
+
+def read_rinex_nav_header(path: Union[str, Path]) -> dict[str, Union[int, None]]:
+    """Read a few selected fields from a RINEX nav file header.
+
+    The compiled parser does not surface the header. This pure-Python scan
+    reads only the lines up to ``END OF HEADER`` and extracts:
+
+    - ``leap_seconds`` : int or None
+        Value of the ``LEAP SECONDS`` header field (UTC -> GPST offset). ``None``
+        if the field is absent.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the RINEX navigation file (.rnx, .nav, or .gz).
+
+    Returns
+    -------
+    dict
+        Header fields. Currently ``{"leap_seconds": int | None}``.
+    """
+    leap_seconds: Union[int, None] = None
+    with _open_rinex_text(path) as fh:
+        for raw_line in fh:
+            line = raw_line.rstrip("\n").rstrip("\r")
+            # RINEX header label occupies columns 60-80 (0-indexed 60:80).
+            label = line[60:80].strip() if len(line) >= 60 else ""
+            if label == "LEAP SECONDS":
+                # The first numeric token in the data area is the leap-second count.
+                # RINEX 3 may carry up to four integer fields (LS, ΔLS_future,
+                # week, day) — we only need the first.
+                token = line[:60].split()
+                if token:
+                    try:
+                        leap_seconds = int(token[0])
+                    except ValueError:
+                        leap_seconds = None
+            if label == "END OF HEADER":
+                break
+    return {"leap_seconds": leap_seconds}
 
 
 def read_rinex_nav(path: Union[str, Path]) -> dict[str, pl.DataFrame]:

--- a/pytecgg/satellites/constants.py
+++ b/pytecgg/satellites/constants.py
@@ -279,3 +279,13 @@ TOL_KEPLER: float = 0.001
 
 # Earth radius in meters
 RE: float = 6371000.0
+
+# Default leap-second count (UTC -> GPST) used when the RINEX header does not
+# carry a LEAP SECONDS field. Current as of IERS Bulletin C (last leap second
+# 2017-01-01). Override at runtime via GNSSContext.leap_seconds, populated from
+# read_rinex_nav_header().
+DEFAULT_LEAP_SECONDS_UTC_GPST: int = 18
+
+# BeiDou time (BDT) trails GPST by a fixed 14 s (BDS ICD, BDT epoch 2006-01-01).
+# This is a constant defined by the ICD and never changes.
+BDT_OFFSET_FROM_GPST: int = 14

--- a/pytecgg/satellites/ephemeris.py
+++ b/pytecgg/satellites/ephemeris.py
@@ -15,8 +15,10 @@ from pytecgg.context import GNSSContext
 Ephem = dict[str, dict[str, Any] | list[dict[str, Any]]]
 """Type alias for a dictionary containing processed ephemeris data.
 
-It maps satellite IDs (e.g., 'G01') to their specific orbital parameters, 
-handling both Keplerian (single dict) and state-vector (list of dicts) models.
+It maps satellite IDs (e.g., 'G01') to their orbital parameters. Values are
+a list of broadcast records for every constellation (Keplerian and
+state-vector); downstream code picks the record nearest the observation
+epoch. A plain dict is still accepted for legacy / hand-built ephemerides.
 """
 
 
@@ -83,13 +85,22 @@ def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
     their specific orbit propagation models:
 
     1.  Keplerian Orbits (GPS, Galileo, BeiDou):
-        Selects a single representative ephemeris message (the central one) per satellite.
+        Keeps every valid broadcast record per satellite. Position computation
+        later picks the record nearest to the observation epoch, since broadcast
+        Keplerian parameters are only valid for ~±2 h around toe. Records
+        corrupted by the rinex-crate week-rollover bug are filtered out (see
+        ``_drop_week_rollover_bug``).
 
     2.  State-Vector Orbits (GLONASS):
         All available ephemeris messages are collected for the satellite. This is
         required because GLONASS messages contain instantaneous state vectors (position/
         velocity/acceleration) valid only for short periods (typically ± 15 minutes),
         requiring numerical integration from the closest epoch.
+
+    Each record carries the ``leap_seconds`` value taken from
+    ``ctx.leap_seconds`` (populated from the RINEX nav header via
+    :func:`pytecgg.parsing.read_rinex_nav_header`) or
+    ``DEFAULT_LEAP_SECONDS_UTC_GPST`` when the context does not provide one.
 
     Parameters
     ----------
@@ -101,8 +112,8 @@ def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
     Returns
     -------
     Ephem
-        Dictionary keyed by satellite ID (e.g., 'G01', 'R09').
-        Values are a single dict for Keplerian systems or a list of dicts for GLONASS.
+        Dictionary keyed by satellite ID (e.g., 'G01', 'R09'). Values are a
+        list of broadcast records (one dict per valid message).
     """
     ephem_dict: Ephem = {}
     inverse_map = ctx.symbol_to_name

--- a/pytecgg/satellites/ephemeris.py
+++ b/pytecgg/satellites/ephemeris.py
@@ -3,7 +3,12 @@ from typing import Any
 
 import polars as pl
 
-from .constants import CONSTELLATION_PARAMS, GPS_EPOCH, KEPLERIAN_POSITION_FIELDS
+from .constants import (
+    CONSTELLATION_PARAMS,
+    DEFAULT_LEAP_SECONDS_UTC_GPST,
+    GPS_EPOCH,
+    KEPLERIAN_POSITION_FIELDS,
+)
 from pytecgg.context import GNSSContext
 
 Ephem = dict[str, dict[str, Any] | list[dict[str, Any]]]
@@ -53,6 +58,9 @@ def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
     """
     ephem_dict: Ephem = {}
     inverse_map = ctx.symbol_to_name
+    leap_seconds = (
+        ctx.leap_seconds if ctx.leap_seconds is not None else DEFAULT_LEAP_SECONDS_UTC_GPST
+    )
 
     for symbol_ in ctx.systems:
         const_name = inverse_map.get(symbol_)
@@ -89,6 +97,7 @@ def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
                         "datetime": ephe_time,
                         "gps_week": gps_week,
                         "gps_seconds": gps_sec,
+                        "leap_seconds": leap_seconds,
                         **{field: row.get(field) for field in params.fields},
                     }
                     sat_ephems_list.append(ephem)
@@ -96,26 +105,33 @@ def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
                 ephem_dict[normalised_sat_id] = sat_ephems_list
 
             else:
-                # Keplerian models (GPS, Galileo, BeiDou) use a single representative message to minimise computational cost.
+                # Keplerian models (GPS, Galileo, BeiDou): keep every valid record
+                # so the caller can pick the one nearest to the observation epoch.
+                # Broadcast Keplerian parameters are only valid for ~±2 h around toe,
+                # so reusing one record across a multi-hour file causes 50-200 m bias.
                 # Validate only on fields required for position computation, not all EPHEMERIS_FIELDS
                 # (e.g. bgdE5bE1 for Galileo may be absent for I/NAV-only satellites).
                 position_fields = [f for f in KEPLERIAN_POSITION_FIELDS if f in sat_data.columns]
-                valid_data = sat_data.drop_nulls(subset=position_fields)
+                valid_data = sat_data.drop_nulls(subset=position_fields).sort("epoch")
                 if valid_data.is_empty():
                     continue
 
-                ephe_row = valid_data.row(len(valid_data) // 2, named=True)
-                ephe_time = ephe_row["epoch"]
-                gps_week, gps_sec = _get_gps_time(ephe_time)
+                sat_ephems_list = []
+                for row in valid_data.to_dicts():
+                    ephe_time = row["epoch"]
+                    gps_week, gps_sec = _get_gps_time(ephe_time)
 
-                ephem = {
-                    "constellation": const_name,
-                    "sv": normalised_sat_id,
-                    "datetime": ephe_time,
-                    "gps_week": gps_week,
-                    "gps_seconds": gps_sec,
-                    **{field: ephe_row.get(field) for field in params.fields},
-                }
-                ephem_dict[normalised_sat_id] = ephem
+                    ephem = {
+                        "constellation": const_name,
+                        "sv": normalised_sat_id,
+                        "datetime": ephe_time,
+                        "gps_week": gps_week,
+                        "gps_seconds": gps_sec,
+                        "leap_seconds": leap_seconds,
+                        **{field: row.get(field) for field in params.fields},
+                    }
+                    sat_ephems_list.append(ephem)
+
+                ephem_dict[normalised_sat_id] = sat_ephems_list
 
     return ephem_dict

--- a/pytecgg/satellites/ephemeris.py
+++ b/pytecgg/satellites/ephemeris.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 from typing import Any
 
@@ -25,6 +26,53 @@ def _get_gps_time(dt: datetime) -> tuple[int, float]:
     gps_week = delta.days // 7
     gps_seconds = (delta.days % 7) * 86400 + delta.seconds + delta.microseconds / 1e6
     return gps_week, gps_seconds
+
+
+# Broadcast ephemeris cadence (seconds) per Keplerian constellation, used to
+# detect a known rinex-crate parsing bug at the BDT/GST week rollover.
+_KEPLERIAN_CADENCE_S: dict[str, float] = {
+    "BEIDOU": 3600.0,
+    "GALILEO": 600.0,
+    "GPS": 7200.0,
+}
+
+
+def _drop_week_rollover_bug(
+    valid_data: pl.DataFrame, const_name: str, sv_id: str
+) -> pl.DataFrame:
+    """Drop ephemeris records corrupted by the rinex-crate (<=0.22) toe bug.
+
+    The crate misreads the toe field at the very first record of a new BDT/GST
+    week (toc seconds-of-week == 0), returning one broadcast-cadence step
+    instead of 0.0. The corrupted record's Keplerian propagation is off by one
+    cadence step, producing ~13000 km position errors for BeiDou MEO and
+    ~2300 km for Galileo MEO. We drop such records and warn the caller;
+    propagation falls back to the next valid record.
+    """
+    cadence = _KEPLERIAN_CADENCE_S.get(const_name)
+    if cadence is None or "toe" not in valid_data.columns:
+        return valid_data
+
+    mask_bad = (
+        (pl.col("epoch").dt.weekday() == 7)
+        & (pl.col("epoch").dt.hour() == 0)
+        & (pl.col("epoch").dt.minute() == 0)
+        & (pl.col("epoch").dt.second() == 0)
+        & (pl.col("toe") == cadence)
+    )
+    bad_count = valid_data.filter(mask_bad).height
+    if bad_count == 0:
+        return valid_data
+
+    warnings.warn(
+        f"Dropped {bad_count} {const_name} ephemeris record(s) for {sv_id} "
+        f"at BDT/GST week rollover: rinex-crate toe parsing bug returned "
+        f"toe={cadence:.0f}s where the file says 0.0s. Affected epoch(s) "
+        f"will fall back to the next valid record (~{cadence/60:.0f} min "
+        f"later) for position propagation.",
+        stacklevel=3,
+    )
+    return valid_data.filter(~mask_bad)
 
 
 def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
@@ -113,6 +161,7 @@ def prepare_ephemeris(nav: dict[str, pl.DataFrame], ctx: GNSSContext) -> Ephem:
                 # (e.g. bgdE5bE1 for Galileo may be absent for I/NAV-only satellites).
                 position_fields = [f for f in KEPLERIAN_POSITION_FIELDS if f in sat_data.columns]
                 valid_data = sat_data.drop_nulls(subset=position_fields).sort("epoch")
+                valid_data = _drop_week_rollover_bug(valid_data, const_name, normalised_sat_id)
                 if valid_data.is_empty():
                     continue
 

--- a/pytecgg/satellites/kepler/coordinates.py
+++ b/pytecgg/satellites/kepler/coordinates.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 
 import numpy as np
 
-from ..constants import GNSS_CONSTANTS
+from ..constants import DEFAULT_LEAP_SECONDS_UTC_GPST, GNSS_CONSTANTS
 from pytecgg.satellites.kepler.orbits import (
     _is_ephemeris_valid,
     _compute_time_elapsed,
@@ -72,6 +72,15 @@ def _kepler_satellite_coordinates(
         raise KeyError(f"Satellite {sv_id} not found in ephemeris data")
 
     data = ephem_dict[sv_id]
+    # prepare_ephemeris now stores a list of broadcast records per Keplerian SV.
+    # Pick the one nearest to obs_time when called with the full list.
+    if isinstance(data, list):
+        if not data:
+            return np.array([], dtype=float)
+        if obs_time is not None:
+            data = min(data, key=lambda r: abs(r["datetime"] - obs_time))
+        else:
+            data = data[len(data) // 2]
     if not _is_ephemeris_valid(data, sv_id, REQUIRED_KEYS):
         return np.array([], dtype=float)
 
@@ -82,7 +91,11 @@ def _kepler_satellite_coordinates(
         A = data["sqrta"] ** 2
         n0 = np.sqrt(gm / (A**3))
         tk = _compute_time_elapsed(
-            computation_time, gps_week=data["gps_week"], toe=data["toe"]
+            computation_time,
+            gps_week=data["gps_week"],
+            toe=data["toe"],
+            gnss_system=gnss_system,
+            leap_seconds=data.get("leap_seconds", DEFAULT_LEAP_SECONDS_UTC_GPST),
         )
 
         # Orbital parameters
@@ -106,11 +119,23 @@ def _kepler_satellite_coordinates(
         rk = A * (1 - data["e"] * np.cos(Ek)) + delta_rk
         ik = data["i0"] + data["idot"] * tk + delta_ik
 
+        # BeiDou GEO satellites are propagated in an inertial frame first,
+        # then rotated to ECEF by _apply_geo_correction below (BDS ICD B1I
+        # §5.2.4.12). Other Keplerian sats fold the ECEF rotation into lamk
+        # via the -we*tk term.
+        is_beidou_geo = gnss_system == "BEIDOU" and data["i0"] <= 20 * (np.pi / 180)
+
         # Longitude of ascending node
-        lamk = np.fmod(
-            data["omega0"] + (data["omegaDot"] - we) * tk - we * data["toe"],
-            2 * np.pi,
-        )
+        if is_beidou_geo:
+            lamk = np.fmod(
+                data["omega0"] + data["omegaDot"] * tk - we * data["toe"],
+                2 * np.pi,
+            )
+        else:
+            lamk = np.fmod(
+                data["omega0"] + (data["omegaDot"] - we) * tk - we * data["toe"],
+                2 * np.pi,
+            )
 
         # Position in orbital plane
         xDash, yDash = rk * np.cos(uk), rk * np.sin(uk)
@@ -120,10 +145,8 @@ def _kepler_satellite_coordinates(
         Yk = xDash * np.sin(lamk) + yDash * np.cos(ik) * np.cos(lamk)
         Zk = yDash * np.sin(ik)
 
-        if gnss_system == "BEIDOU":
-            # GEO orbits correction
-            if data["i0"] <= 20 * (np.pi / 180):
-                Xk, Yk, Zk = _apply_geo_correction(Xk, Yk, Zk, tk, we)
+        if is_beidou_geo:
+            Xk, Yk, Zk = _apply_geo_correction(Xk, Yk, Zk, tk, we)
 
         return np.array([Xk, Yk, Zk], dtype=float)
 

--- a/pytecgg/satellites/kepler/orbits.py
+++ b/pytecgg/satellites/kepler/orbits.py
@@ -1,9 +1,10 @@
 import datetime
 import warnings
+from typing import Optional
 
 import numpy as np
 
-from ..constants import TOL_KEPLER
+from ..constants import BDT_OFFSET_FROM_GPST, DEFAULT_LEAP_SECONDS_UTC_GPST, TOL_KEPLER
 
 
 def _is_ephemeris_valid(data: dict, sv_id: str, required_keys: dict) -> bool:
@@ -25,25 +26,61 @@ def _gps_to_datetime(time_week, time_s, leap_seconds=0):
     )
 
 
+def _utc_to_system_time(
+    obs_time_utc: datetime.datetime,
+    gnss_system: Optional[str],
+    leap_seconds: int,
+) -> datetime.datetime:
+    """Shift a UTC observation datetime into the constellation's time system.
+
+    GPS / Galileo / QZSS reference broadcast ephemerides to GPST, BeiDou to BDT,
+    GLONASS to UTC. The ICDs fix all offsets:
+
+    - GPST = UTC + leap_seconds (currently 18 s, IERS Bulletin C).
+    - GST  = GPST (Galileo ICD).
+    - QZSST = GPST (QZSS ICD).
+    - BDT  = GPST - 14 s (BDS ICD, BDT epoch 2006-01-01).
+    - GLONASS uses UTC directly (no shift).
+    """
+    if gnss_system in ("GPS", "GALILEO", "QZSS"):
+        return obs_time_utc + datetime.timedelta(seconds=leap_seconds)
+    if gnss_system == "BEIDOU":
+        return obs_time_utc + datetime.timedelta(
+            seconds=leap_seconds - BDT_OFFSET_FROM_GPST
+        )
+    return obs_time_utc
+
+
 def _compute_time_elapsed(
-    obs_time: datetime.datetime, gps_week: int, toe: int
+    obs_time: datetime.datetime,
+    gps_week: int,
+    toe: int,
+    gnss_system: Optional[str] = None,
+    leap_seconds: int = DEFAULT_LEAP_SECONDS_UTC_GPST,
 ) -> float:
-    """Compute the time elapsed since the ephemeris reference epoch (ToE)"""
+    """Compute the time elapsed since the ephemeris reference epoch (ToE).
+
+    ``obs_time`` is interpreted as UTC and shifted into the constellation's
+    own time system before subtracting the toe. ``gnss_system`` selects which
+    offset applies (GPST / GST / BDT / UTC for GLONASS).
+    """
     if not isinstance(obs_time, datetime.datetime):
         raise TypeError("Invalid datetime format in ephemeris data")
+
+    # Ensure obs_time is tz-aware UTC before applying the leap-second shift.
+    if obs_time.tzinfo is None:
+        obs_time = obs_time.replace(tzinfo=datetime.timezone.utc)
+
+    obs_time_in_sys = _utc_to_system_time(obs_time, gnss_system, leap_seconds)
 
     toe_dt = _gps_to_datetime(
         time_week=gps_week,
         time_s=toe,
     )
-
-    # Ensure both times are tz-aware
-    if obs_time.tzinfo is not None and toe_dt.tzinfo is None:
+    if toe_dt.tzinfo is None:
         toe_dt = toe_dt.replace(tzinfo=datetime.timezone.utc)
-    elif obs_time.tzinfo is None and toe_dt.tzinfo is not None:
-        obs_time = obs_time.replace(tzinfo=datetime.timezone.utc)
 
-    return (obs_time - toe_dt).total_seconds()
+    return (obs_time_in_sys - toe_dt).total_seconds()
 
 
 def _kepler(e: float, mk: float, tol: float) -> float:

--- a/pytecgg/satellites/positions.py
+++ b/pytecgg/satellites/positions.py
@@ -13,6 +13,22 @@ from pytecgg.satellites.state_vector.coordinates import (
 PREFIX_MAP = {v: k for k, v in SUPPORTED_SYSTEMS.items()}
 
 
+def _pick_nearest_keplerian_record(
+    records: Union[dict[str, Any], list[dict[str, Any]]],
+    epoch: Any,
+) -> Union[dict[str, Any], None]:
+    """Pick the broadcast record whose datetime is nearest to `epoch`.
+
+    Accepts either a list of records (current format) or a single record dict
+    (legacy format) so manually built ephem_dicts keep working.
+    """
+    if isinstance(records, dict):
+        return records
+    if not records:
+        return None
+    return min(records, key=lambda r: abs(r["datetime"] - epoch))
+
+
 def _infer_schema_overrides(records: list[dict[str, Any]]) -> dict[str, pl.DataType]:
     """Infer stable schema overrides for mixed GLONASS ephemeris records."""
     overrides: dict[str, pl.DataType] = {}
@@ -101,11 +117,6 @@ def _compute_coordinates(
         DataFrame with columns: 'sv', 'epoch', 'sat_x', 'sat_y', 'sat_z'
         containing satellite ECEF coordinates in meters.
     """
-    sv_arr = sv_ids.to_numpy()
-    size = len(sv_arr)
-
-    x, y, z = np.full(size, np.nan), np.full(size, np.nan), np.full(size, np.nan)
-
     # Track satellites with no or problematic ephemeris for warnings
     missing_eph = set()
     calculation_failed = set()
@@ -116,7 +127,18 @@ def _compute_coordinates(
 
     # GLONASS (State-vector integration logic)
     if isinstance(ephem_data, pl.DataFrame):
+        # ephem_data is the join_asof result, which is sorted by (sv, epoch).
+        # Use its sv/epoch columns for the output so each computed (x, y, z)
+        # stays aligned with the corresponding input pair — using the unsorted
+        # input series here would mis-align rows.
         data_rows = ephem_data.to_dicts()
+        size = len(data_rows)
+        out_sv = [row["sv"] for row in data_rows]
+        out_epoch = [row["epoch"] for row in data_rows]
+        x = np.full(size, np.nan)
+        y = np.full(size, np.nan)
+        z = np.full(size, np.nan)
+
         for i, row in enumerate(data_rows):
             sv_id = row["sv"]
 
@@ -137,13 +159,27 @@ def _compute_coordinates(
 
     # Keplerian systems (GPS, Galileo, BeiDou, QZSS)
     else:
+        sv_arr = sv_ids.to_numpy()
+        size = len(sv_arr)
+        out_sv = sv_arr
+        out_epoch = epochs
+        x = np.full(size, np.nan)
+        y = np.full(size, np.nan)
+        z = np.full(size, np.nan)
+
         for i, (sv, epoch) in enumerate(zip(sv_arr, epochs)):
-            if sv not in ephem_data:
+            records = ephem_data.get(sv)
+            if not records:
+                missing_eph.add(sv)
+                continue
+
+            chosen = _pick_nearest_keplerian_record(records, epoch)
+            if chosen is None:
                 missing_eph.add(sv)
                 continue
 
             try:
-                pos = coord_func(ephem_data, sv, system_label, epoch, **kwargs)
+                pos = coord_func({sv: chosen}, sv, system_label, epoch, **kwargs)
                 if pos is not None and pos.size == 3:
                     x[i], y[i], z[i] = pos
                 else:
@@ -156,8 +192,8 @@ def _compute_coordinates(
 
     return pl.DataFrame(
         {
-            "sv": sv_arr,
-            "epoch": epochs,
+            "sv": out_sv,
+            "epoch": out_epoch,
             "sat_x": x,
             "sat_y": y,
             "sat_z": z,

--- a/tests/test_ephemeris.py
+++ b/tests/test_ephemeris.py
@@ -43,5 +43,9 @@ def test_prepare_ephemeris_nav_v3(nav_v3_file):
     for sat, eph in ephemeris.items():
         assert sat.startswith("G")
         assert len(sat) == 3
-        assert eph["datetime"].tzinfo is not None
-        assert eph["constellation"] == "GPS"
+        # Keplerian SVs now carry the full list of broadcast records so
+        # downstream code can pick the one nearest to obs_time.
+        assert isinstance(eph, list) and eph, f"expected non-empty list for {sat}"
+        for record in eph:
+            assert record["datetime"].tzinfo is not None
+            assert record["constellation"] == "GPS"

--- a/tests/test_ephemeris.py
+++ b/tests/test_ephemeris.py
@@ -5,7 +5,12 @@ import polars as pl
 
 from pytecgg.context import GNSSContext
 from pytecgg.parsing import read_rinex_nav
-from pytecgg.satellites.ephemeris import _get_gps_time, prepare_ephemeris
+from pytecgg.satellites.ephemeris import (
+    _KEPLERIAN_CADENCE_S,
+    _drop_week_rollover_bug,
+    _get_gps_time,
+    prepare_ephemeris,
+)
 
 
 def test_get_gps_time():
@@ -49,3 +54,81 @@ def test_prepare_ephemeris_nav_v3(nav_v3_file):
         for record in eph:
             assert record["datetime"].tzinfo is not None
             assert record["constellation"] == "GPS"
+
+
+def _bad_row(epoch: datetime, cadence: float) -> dict:
+    return {"epoch": epoch, "toe": cadence}
+
+
+def _good_row(epoch: datetime, toe: float) -> dict:
+    return {"epoch": epoch, "toe": toe}
+
+
+def test_drop_week_rollover_bug_drops_corrupted_beidou_row():
+    """At BDT Sunday 00:00:00, toe = cadence is the rinex-crate bug signature."""
+    cadence = _KEPLERIAN_CADENCE_S["BEIDOU"]
+    rollover_sunday = datetime(2025, 1, 5, 0, 0, 0)  # Sunday 00:00:00
+    df = pl.DataFrame(
+        [
+            _bad_row(rollover_sunday, cadence),
+            _good_row(datetime(2025, 1, 5, 1, 0, 0), cadence),
+            _good_row(datetime(2025, 1, 5, 2, 0, 0), 7200.0),
+        ]
+    )
+
+    with pytest.warns(UserWarning, match="week rollover"):
+        out = _drop_week_rollover_bug(df, "BEIDOU", "C01")
+
+    assert out.height == 2
+    assert rollover_sunday not in out["epoch"].to_list()
+
+
+def test_drop_week_rollover_bug_leaves_other_records_alone():
+    """A toe equal to cadence on any non-rollover epoch must NOT be dropped."""
+    cadence = _KEPLERIAN_CADENCE_S["GALILEO"]
+    df = pl.DataFrame(
+        [
+            # Sunday but not at 00:00:00 -> keep
+            _bad_row(datetime(2025, 1, 5, 0, 10, 0), cadence),
+            # Monday at 00:00:00 -> keep (weekday() != 7)
+            _bad_row(datetime(2025, 1, 6, 0, 0, 0), cadence),
+        ]
+    )
+
+    out = _drop_week_rollover_bug(df, "GALILEO", "E01")
+
+    assert out.height == 2
+
+
+def test_drop_week_rollover_bug_noop_for_glonass():
+    """GLONASS has no cadence entry, so the filter is a no-op."""
+    df = pl.DataFrame([{"epoch": datetime(2025, 1, 5, 0, 0, 0), "toe": 600.0}])
+
+    out = _drop_week_rollover_bug(df, "GLONASS", "R01")
+
+    assert out.height == 1
+
+
+def test_prepare_ephemeris_populates_leap_seconds(nav_v3_file):
+    """Each record must carry leap_seconds, defaulting when ctx leaves it None."""
+    nav_data = read_rinex_nav(nav_v3_file)
+
+    ctx_default = GNSSContext(
+        receiver_pos=(0.0, 0.0, 0.0),
+        receiver_name="TEST",
+        rinex_version="3.04",
+        systems=["G"],
+    )
+    ephem_default = prepare_ephemeris(nav_data, ctx_default)
+    any_sv = next(iter(ephem_default))
+    assert ephem_default[any_sv][0]["leap_seconds"] == 18  # DEFAULT_LEAP_SECONDS_UTC_GPST
+
+    ctx_override = GNSSContext(
+        receiver_pos=(0.0, 0.0, 0.0),
+        receiver_name="TEST",
+        rinex_version="3.04",
+        systems=["G"],
+        leap_seconds=37,
+    )
+    ephem_override = prepare_ephemeris(nav_data, ctx_override)
+    assert ephem_override[any_sv][0]["leap_seconds"] == 37

--- a/tests/test_kepler.py
+++ b/tests/test_kepler.py
@@ -1,6 +1,15 @@
+import datetime
+
+import pytest
 from math import isclose, pi
-from pytecgg.satellites.kepler.orbits import _kepler
 from numpy import sin
+
+from pytecgg.satellites.constants import BDT_OFFSET_FROM_GPST
+from pytecgg.satellites.kepler.orbits import (
+    _compute_time_elapsed,
+    _kepler,
+    _utc_to_system_time,
+)
 
 
 def test_kepler_circular_orbit():
@@ -33,3 +42,75 @@ def test_kepler_close_to_parabolic():
     ek = _kepler(e, mk, tol=0.01)
     lhs = ek - e * sin(ek)
     assert isclose(lhs, mk, abs_tol=0.01 * (pi / 648_000))
+
+
+# Time-system conversion (UTC -> GPST/GST/BDT/UTC)
+
+_UTC_REF = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@pytest.mark.parametrize("system", ["GPS", "GALILEO", "QZSS"])
+def test_utc_to_system_time_gpst_family_adds_leap_seconds(system):
+    """GPST = UTC + leap_seconds; GST and QZSST align with GPST."""
+    out = _utc_to_system_time(_UTC_REF, system, leap_seconds=18)
+    assert (out - _UTC_REF).total_seconds() == 18
+
+
+def test_utc_to_system_time_beidou_subtracts_bdt_offset():
+    """BDT = GPST - BDT_OFFSET_FROM_GPST (14 s, fixed by BDS ICD)."""
+    out = _utc_to_system_time(_UTC_REF, "BEIDOU", leap_seconds=18)
+    assert (out - _UTC_REF).total_seconds() == 18 - BDT_OFFSET_FROM_GPST
+
+
+def test_utc_to_system_time_glonass_is_identity():
+    """GLONASS uses UTC directly: no shift applied."""
+    out = _utc_to_system_time(_UTC_REF, "GLONASS", leap_seconds=18)
+    assert out == _UTC_REF
+
+
+def test_utc_to_system_time_unknown_system_falls_back_to_utc():
+    out = _utc_to_system_time(_UTC_REF, None, leap_seconds=18)
+    assert out == _UTC_REF
+
+
+def test_compute_time_elapsed_applies_leap_seconds_for_gps():
+    """GPS path shifts UTC into GPST before subtracting toe.
+
+    Two identical UTC obs_times with different leap_seconds must produce
+    elapsed values differing by exactly the leap-second delta.
+    """
+    # 2024-01-01 12:00:00 UTC <-> GPS week 2295, seconds 129600
+    obs = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    gps_week = 2295
+    toe = 129600
+
+    dt_18 = _compute_time_elapsed(obs, gps_week, toe, gnss_system="GPS", leap_seconds=18)
+    dt_20 = _compute_time_elapsed(obs, gps_week, toe, gnss_system="GPS", leap_seconds=20)
+
+    assert dt_20 - dt_18 == 2.0
+
+
+def test_compute_time_elapsed_beidou_offset_relative_to_gps():
+    """For the same UTC obs_time, BeiDou elapsed = GPS elapsed - 14 s."""
+    obs = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    gps_week = 2295
+    toe = 129600
+
+    dt_gps = _compute_time_elapsed(obs, gps_week, toe, gnss_system="GPS", leap_seconds=18)
+    dt_bdt = _compute_time_elapsed(
+        obs, gps_week, toe, gnss_system="BEIDOU", leap_seconds=18
+    )
+
+    assert dt_gps - dt_bdt == BDT_OFFSET_FROM_GPST
+
+
+def test_compute_time_elapsed_naive_obs_is_treated_as_utc():
+    """A tz-naive obs_time must be promoted to UTC, not raise."""
+    obs_naive = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    gps_week = 2295
+    toe = 129600
+
+    dt = _compute_time_elapsed(
+        obs_naive, gps_week, toe, gnss_system="GPS", leap_seconds=18
+    )
+    assert dt == 18.0

--- a/tests/test_parsing_header.py
+++ b/tests/test_parsing_header.py
@@ -1,0 +1,64 @@
+"""Tests for ``read_rinex_nav_header`` — the pure-Python header scanner."""
+
+import gzip
+
+from pytecgg.parsing import read_rinex_nav_header
+
+# Minimal RINEX 3 nav header. Column 60-80 carries the label.
+_HEADER_WITH_LEAP = (
+    "     3.04           N: GNSS NAV DATA    M: MIXED            RINEX VERSION / TYPE\n"
+    "ConvBin 0.1.0       AC                  20250328 000000 UTC PGM / RUN BY / DATE\n"
+    "    18    18  2185     7                                    LEAP SECONDS\n"
+    "                                                            END OF HEADER\n"
+    "G01 2025 03 28 00 00 00 1.0e-04 0.0 0.0\n"  # one fake nav record after header
+)
+
+_HEADER_WITHOUT_LEAP = (
+    "     3.04           N: GNSS NAV DATA    M: MIXED            RINEX VERSION / TYPE\n"
+    "ConvBin 0.1.0       AC                  20250328 000000 UTC PGM / RUN BY / DATE\n"
+    "                                                            END OF HEADER\n"
+)
+
+
+def test_read_rinex_nav_header_extracts_leap_seconds(tmp_path):
+    nav_file = tmp_path / "fake.rnx"
+    nav_file.write_text(_HEADER_WITH_LEAP, encoding="ascii")
+
+    header = read_rinex_nav_header(nav_file)
+
+    assert header == {"leap_seconds": 18}
+
+
+def test_read_rinex_nav_header_returns_none_when_field_absent(tmp_path):
+    nav_file = tmp_path / "no_leap.rnx"
+    nav_file.write_text(_HEADER_WITHOUT_LEAP, encoding="ascii")
+
+    header = read_rinex_nav_header(nav_file)
+
+    assert header == {"leap_seconds": None}
+
+
+def test_read_rinex_nav_header_handles_gzipped_input(tmp_path):
+    nav_file = tmp_path / "fake.rnx.gz"
+    with gzip.open(nav_file, "wt", encoding="ascii") as fh:
+        fh.write(_HEADER_WITH_LEAP)
+
+    header = read_rinex_nav_header(nav_file)
+
+    assert header == {"leap_seconds": 18}
+
+
+def test_read_rinex_nav_header_stops_at_end_of_header(tmp_path):
+    """Body lines containing 'LEAP SECONDS' must not be parsed after END OF HEADER."""
+    nav_file = tmp_path / "stop.rnx"
+    body = (
+        "     3.04           N: GNSS NAV DATA    M: MIXED            RINEX VERSION / TYPE\n"
+        "                                                            END OF HEADER\n"
+        # If the scanner kept reading, the line below would set leap_seconds=99.
+        "    99    18  2185     7                                    LEAP SECONDS\n"
+    )
+    nav_file.write_text(body, encoding="ascii")
+
+    header = read_rinex_nav_header(nav_file)
+
+    assert header == {"leap_seconds": None}

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,9 +1,12 @@
+import datetime
+
 import numpy as np
 import polars as pl
 
 from pytecgg.satellites.kepler.orbits import _apply_geo_correction, _compute_anomalies
 from pytecgg.satellites import GNSS_CONSTANTS
 from pytecgg.satellites import positions as positions_module
+from pytecgg.satellites.positions import _pick_nearest_keplerian_record
 
 
 # def test_numerical_output(ephemeris_data):
@@ -94,3 +97,38 @@ def test_glonass_ephemeris_schema_preserves_string_fields(monkeypatch):
 
     assert not result.is_empty()
     assert captured["schema"]["constellation"] == pl.String
+
+
+# _pick_nearest_keplerian_record
+
+
+def _record(dt: datetime.datetime) -> dict:
+    return {"datetime": dt, "toe": 0.0}
+
+
+def test_pick_nearest_keplerian_record_chooses_closest():
+    epoch = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    records = [
+        _record(datetime.datetime(2025, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)),
+        _record(datetime.datetime(2025, 1, 1, 11, 30, 0, tzinfo=datetime.timezone.utc)),
+        _record(datetime.datetime(2025, 1, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)),
+    ]
+
+    chosen = _pick_nearest_keplerian_record(records, epoch)
+
+    assert chosen is records[1]
+
+
+def test_pick_nearest_keplerian_record_accepts_legacy_dict():
+    """Manually built single-dict ephem entries must still work."""
+    epoch = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    record = _record(datetime.datetime(2025, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc))
+
+    chosen = _pick_nearest_keplerian_record(record, epoch)
+
+    assert chosen is record
+
+
+def test_pick_nearest_keplerian_record_empty_list_returns_none():
+    epoch = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    assert _pick_nearest_keplerian_record([], epoch) is None


### PR DESCRIPTION
## Summary

Three related fixes to the Keplerian satellite-position pipeline (GPS / Galileo / BeiDou) that remove systematic propagation biases, plus the supporting docs and unit tests.

### 1. Leap seconds and constellation time systems (`912cae3`)
Broadcast ephemerides are referenced to each constellation's own time system (GPST / GST / BDT), not UTC. The pipeline was treating `obs_time` as if it were already in the constellation's time system, introducing a propagation bias equal to the current leap-second count (18 s) for GPS/Galileo/QZSS and 18 − 14 = 4 s for BeiDou.

- `parsing.read_rinex_nav_header`: new pure-Python header scanner that extracts the `LEAP SECONDS` field from RINEX nav files (also handles `.gz`).
- `GNSSContext.leap_seconds`: new optional field, falling back to `DEFAULT_LEAP_SECONDS_UTC_GPST = 18` when the RINEX header is missing it.
- `constants`: added `DEFAULT_LEAP_SECONDS_UTC_GPST` and `BDT_OFFSET_FROM_GPST = 14` (BDS ICD constant).
- `kepler.orbits._utc_to_system_time`: shifts the UTC observation epoch into the constellation's time system before computing `tk = obs_time − toe`.
- `kepler.coordinates`: corrected the ECEF rotation handling for BeiDou GEO satellites (the `is_beidou_geo` branch is now isolated).

### 2. Nearest Keplerian record per epoch (`912cae3`)
`prepare_ephemeris` previously kept a single "representative" (central) record per Keplerian satellite. Reusing one record across a multi-hour file caused 50–200 m position errors because broadcast Keplerian parameters are only valid for ~±2 h around `toe`.

- `prepare_ephemeris`: now stores the **full list** of valid broadcast records per Keplerian SV.
- `positions._pick_nearest_keplerian_record`: helper that picks the record nearest to each observation epoch; accepts the legacy single-dict format for backwards compatibility.
- `positions._compute_coordinates`: GLONASS branch now derives output `sv`/`epoch` from the join-asof result so rows stay aligned after sorting.

### 3. RINEX-crate week-rollover toe bug (`b0ad3ad`)
At the very first record of a new BDT/GST week (toc seconds-of-week == 0) the upstream `rinex` crate (≤ 0.22) misreads the `toe` field, returning one broadcast-cadence step instead of 0.0. The corrupted record produced ~13 000 km errors for BeiDou MEO and ~2300 km for Galileo MEO.

- `ephemeris._drop_week_rollover_bug`: detects the signature (Sunday 00:00:00 epoch + `toe == cadence`) and drops the affected rows, emitting a `UserWarning`. Propagation falls back to the next valid record.
- Cadences encoded in `_KEPLERIAN_CADENCE_S`: BEIDOU 3600 s, GALILEO 600 s, GPS 7200 s.

### 4. Docs and tests (`f9fd710`)
- Refreshed `prepare_ephemeris` docstring and the `Ephem` type alias (Keplerian entries are now lists, not single dicts).
- `docs/reference/satellites.md`: corrected Ephemeris Preparation Notes; added a **Time Systems and Leap Seconds** subsection.
- `docs/reference/parsing.md`: added `read_rinex_nav_header` to the API reference.
- New / extended unit tests:
  - `tests/test_ephemeris.py`: `_drop_week_rollover_bug` (drops BeiDou Sunday-00:00 row when `toe == cadence`, leaves non-rollover rows, no-op for GLONASS); `prepare_ephemeris` propagates `ctx.leap_seconds`.
  - `tests/test_kepler.py`: `_utc_to_system_time` across GPS / Galileo / QZSS / BeiDou / GLONASS / unknown; `_compute_time_elapsed` leap-second delta, BeiDou-vs-GPS offset, naive-UTC promotion.
  - `tests/test_positions.py`: `_pick_nearest_keplerian_record` (closest record, legacy dict, empty list).
  - `tests/test_parsing_header.py` (new): `read_rinex_nav_header` on plain and gzipped files, missing field, END-OF-HEADER stop.